### PR TITLE
list method was updated

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -17,8 +17,13 @@ const getByEndpoint = async (endpoint, headers) => {
 };
 
 const refreshHeaders = async (headers) => {
+	const {page, pageSize, getTotals, getOnlyTotals, ...customHeaders} = headers;
+
 	const oauthTokens = await getTokenAndClient();
-	const updatedHeaders = await updateHeaders(oauthTokens, headers);
+	const updatedHeaders = await updateHeaders(
+		{...oauthTokens, page, pageSize, getTotals, getOnlyTotals},
+		customHeaders,
+	);
 
 	return updatedHeaders;
 };
@@ -133,6 +138,9 @@ class Request {
 				service,
 				this.JANIS_ENV,
 			)}/${namespace}/${parseQueryParams(queryParams)}`;
+
+			crashlytics.log(`URL list: ${validUrl}`);
+
 			const {data, headers: responseHeaders} = await axios.get(validUrl, {
 				headers: updatedHeaders,
 			});


### PR DESCRIPTION
LINK DE TICKET: *
https://janiscommerce.atlassian.net/browse/APPSRN-270

DESCRIPCIÓN DEL REQUERIMIENTO: *

**CONTEXTO:**

Revisando el flujo de picking nos dimos cuenta que, luego de la implementación del package, no estabamos guardando la información de todas las posiciones de consolidation en realm.

Analizando la implementación descubrimos que, del lado del package, los headers correspondientes a “page” y “pageSize” no están actualizando los valores que la request tiene por defecto.

¿Por qué?

Porque, en la función que se encarga de actualizar los headers, estamos pasando estos 2 parametros por fuera del argumento principal, que es el que la función formatea para realizar la request y definir la página y la cantidad de datos que esta debe obtener.

**NECESIDAD:**

Corregir esta implementación para poder modificar los headers en caso de ser necesario.

DESCRIPCIÓN DE LA SOLUCIÓN: *

Se modificó la función refreshHeaders para que destructure las keys "page","pageSize","getTotals" y "getOnlyTotals" del objeto recibido como argumento y poder pasarlas como primer argumento para la función updateHeaders. De esta manera los valores que estas keys reciban en su implementación si impactaran en las request realizadas.

También se añadió un nuevo log dentro del método LIST para que se envíe, en el reporte de crashlytics, la URL a la que se realiza la petición junto a sus query params.

CÓMO SE PUEDE PROBAR? *

Para probarlo debería generar una nueva instancia de la clase Request del package y llamarla en alguna pantalla en la que necesite utilizar una api de formato LIST.

```js
const request = new Request({JANIS_ENV})

const getList = async () => {
const [responseOk, errorResponse] = await promiseWrapper(request.list(
{service: 'picking', namespace:'session',headers:{page:1,pageSize:5}}))
}
console.log(responseOk.result)
console.log(responseOk.result.length)

}
```

De esta manera realizará una request que obtendrá los primeros 5 objetos de la primer página de la api a la que realizará la petición.