### PR TITLE
Fixed headers not being used when there is and endpoint

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -11,7 +11,7 @@ const getByEndpoint = async (endpoint, headers) => {
 	crashlytics.log(`get: ${endpoint}`);
 
 	const {data} = await axios.get(endpoint, {
-		...(headers && isObject(headers) && headers),
+		...(headers && isObject(headers) && {headers}),
 	});
 
 	return data;


### PR DESCRIPTION
**Descripción**

Tras unas pruebas se encontró que el package de app request está fallando al emplear la propiedad endpoint, ya que los headers no se están mandando correctamente

**Acceptance criteria**

Que, al usar endpoint en las api get, los headers se pasen correctamente a axios

**Analisis funcional**

En la función getByEndpoint de lib se le deberá agregar unos corchetes a los headers ya que hoy está así:
`...(headers && isObject(headers) && headers),`
Y deberá quedar así:
`...(headers && isObject(headers) && {headers}),`