### PR TITLE
Appsrn 287 mejorar uso qury params

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,21 +1,9 @@
-import axios from 'axios';
-import {isNumber, isString, isObject, URLMaker, parsePathParams} from './utils/helpers.js';
+import {isString, URLMaker, parsePathParams} from './utils/helpers.js';
 import crashlytics from './utils/crashlytics.js';
 import updateHeaders from './utils/updateHeaders.js';
 import parseQueryParams from './utils/parseQueryParams.js';
-import getApiService from './utils/getApiService.js';
 import getTokenAndClient from './utils/getTokenAndClient.js';
 import makeRequest from './utils/makeRequest.js';
-
-const getByEndpoint = async (endpoint, headers) => {
-	crashlytics.log(`get: ${endpoint}`);
-
-	const {data} = await axios.get(endpoint, {
-		...(headers && isObject(headers) && {headers}),
-	});
-
-	return data;
-};
 
 const refreshHeaders = async (headers) => {
 	const {page, pageSize, getTotals, getOnlyTotals, ...customHeaders} = headers;
@@ -50,47 +38,40 @@ class Request {
 	 * @param {string} params.service Janis service.
 	 * @param {string} params.endpoint External endpoint. If this param is passed, the request will be done directly to the endpoint received.
 	 * @param {object} params.headers Request headers.
+	 * @param {object} params.queryParams Filters and sorts. Will be parsed and added to the url.
+	 * @param {string<Array>} params.pathParams array of string that represent some part of the api/URL
+	 * @param {string} params.action the action that will be performed on the entity
+	 * @param {object} params.extraConfigs any extra configuration for the request
 	 * @returns {Promise<object>} Api response.
 	 * @example
 	 *  const request = new Request({JANIS_ENV: 'janis_dev'})
 	 *  const dataEndpoint = await request.get({endpoint: 'https://test.external.service/file.pdf'})
 	 *  const data = await request.get({service: 'picking', namespace: 'session', id: '123'})
 	 */
-	async get({id = '', namespace = '', service = '', endpoint = '', headers = {}}) {
-		let hasId;
-
-		try {
-			if (endpoint && isString(endpoint)) {
-				const data = await getByEndpoint(endpoint, headers);
-				return data;
-			}
-
-			crashlytics.log(`get: ${service}/${namespace}/${id}`);
-
-			if (!namespace || !isString(namespace)) throw new Error('namespace is not valid');
-			if (!service || !isString(service)) throw new Error('service is not valid');
-			if (!isString(id)) throw new Error('id is not valid');
-
-			const updatedHeaders = await refreshHeaders(headers);
-
-			hasId = !!id;
-
-			const validUrl = `${getApiService(service, this.JANIS_ENV)}/${namespace}${
-				hasId ? `/${id}` : ''
-			}`;
-
-			const {data} = await axios.get(validUrl, {headers: updatedHeaders});
-
-			return data;
-		} catch (error) {
-			const validMessage = error?.response?.data?.message;
-			if (isString(validMessage) && validMessage) error.message = validMessage;
-			crashlytics.recordError(
-				error,
-				`Error at GET:  service: ${service} namespace: ${namespace} ${hasId ? `id: ${id}` : ''}`,
-			);
-			return Promise.reject(error);
-		}
+	async get({
+		id = '',
+		namespace = '',
+		service = '',
+		endpoint = '',
+		headers = {},
+		action = '',
+		queryParams = {},
+		pathParams = [],
+		extraConfigs = {},
+	}) {
+		return this.prepareAndMakeRequest({
+			httpVerb: 'get',
+			endpoint,
+			namespace,
+			service,
+			id,
+			queryParams,
+			pathParams,
+			action,
+			headers,
+			extraConfigs,
+			method: 'GET',
+		});
 	}
 
 	/**
@@ -101,6 +82,10 @@ class Request {
 	 * @param {object} params.queryParams Filters and sorts. Will be parsed and added to the url.
 	 * @param {string} params.namespace Entities namespace.
 	 * @param {string} params.service Janis service.
+	 * @param {string} params.endpoint External endpoint. If this param is passed, the request will be done directly to the endpoint received.
+	 * @param {string<Array>} params.pathParams array of string that represent some part of the api/URL
+	 * @param {string} params.action the action that will be performed on the entity
+	 * @param {object} params.extraConfigs any extra configuration for the request
 	 * @returns {Promise<Array>} Array of entities
 	 * @example
 	 * const request = new Request({JANIS_ENV: 'janis_dev'})
@@ -114,54 +99,28 @@ class Request {
 					},
 				})
    */
-	async list({headers = {}, queryParams = {}, namespace = '', service = ''}) {
-		try {
-			crashlytics.log(`list: ${service}-${namespace}`);
-
-			if (!namespace || !isString(namespace)) throw new Error('namespace is not valid');
-			if (!service || !isString(service)) throw new Error('service is not valid');
-
-			const {
-				page = 1,
-				pageSize = 60,
-				getTotals = false,
-				getOnlyTotals = false,
-				...restHeaders
-			} = headers;
-
-			const updatedHeaders = await refreshHeaders({
-				page,
-				pageSize,
-				getTotals,
-				getOnlyTotals,
-				...restHeaders,
-			});
-
-			const validUrl = `${getApiService(service, this.JANIS_ENV)}/${namespace}/${parseQueryParams(
-				queryParams,
-			)}`;
-
-			crashlytics.log(`URL list: ${validUrl}`);
-
-			const {data, headers: responseHeaders} = await axios.get(validUrl, {
-				headers: updatedHeaders,
-			});
-
-			const {'x-janis-total': totalResult} = responseHeaders;
-			const total = Number(totalResult);
-			const isLastPage = data?.length < pageSize;
-
-			return {
-				result: data,
-				isLastPage,
-				...(total && isNumber(total) && {total}),
-			};
-		} catch (error) {
-			const validMessage = error?.response?.data?.message;
-			if (isString(validMessage) && validMessage) error.message = validMessage;
-			crashlytics.recordError(error, `Error at LIST:  service: ${service} namespace: ${namespace}`);
-			return Promise.reject(error);
-		}
+	async list({
+		headers = {},
+		queryParams = {},
+		namespace = '',
+		service = '',
+		endpoint = '',
+		action = '',
+		pathParams = [],
+		extraConfigs = {},
+	}) {
+		return this.prepareAndMakeRequest({
+			httpVerb: 'get',
+			headers: {page: 1, pageSize: 60, getTotals: false, getOnlyTotals: false, ...headers},
+			endpoint,
+			namespace,
+			service,
+			queryParams,
+			pathParams,
+			action,
+			extraConfigs,
+			method: 'LIST',
+		});
 	}
 
 	/**

--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -1,5 +1,5 @@
 import crashlytics from './crashlytics.js';
-import {isNumber, isObject, isString} from './helpers.js';
+import {isNumber, isObject, isString, isArray} from './helpers.js';
 import axios from 'axios';
 
 const makeRequest = ({httpVerb, url, data, headers, extendedConfig, crashConfig}) =>
@@ -9,7 +9,7 @@ const makeRequest = ({httpVerb, url, data, headers, extendedConfig, crashConfig}
 			url,
 			...extendedConfig,
 			...(!!headers && isObject(headers) && {headers}),
-			...(!!data && isObject(data) && {data}),
+			...(!!data && (isObject(data) || isArray(data)) && {data}),
 		};
 
 		const {method, service, namespace, id} = crashConfig;
@@ -20,9 +20,13 @@ const makeRequest = ({httpVerb, url, data, headers, extendedConfig, crashConfig}
 		axios(config)
 			.then((response) => {
 				const {headers: responseHeaders, status, statusText, data: responseData} = response;
-				const {'x-janis-total': totalResult, ...restHeaders} = responseHeaders;
+				const {
+					'x-janis-total': totalResult,
+					'x-janis-page-size': pageSize,
+					...restHeaders
+				} = responseHeaders;
 				const total = Number(totalResult);
-				const isLastPage = responseData?.length < headers['x-janis-page-size'];
+				const isLastPage = responseData?.length < pageSize;
 
 				resolve({
 					result: responseData,

--- a/lib/utils/parseQueryParams.js
+++ b/lib/utils/parseQueryParams.js
@@ -1,10 +1,10 @@
-import {isObject, isString, isArray} from './helpers.js';
+import {isObject, isArray} from './helpers.js';
 /**
  * @name parseQueryParams
  * @description get the filters and sorting criteria parsed to send to janis api
  * @param {object} queryParams - object with the filters and sorting criteria (each filter and sort is a pair of filter: value)
  * @param {object} queryParams.filters - object with the filters (each property is a pair of filter: value)
- * @param {string} queryParams.sort - string with session sorting criteria
+ * @param {object} queryParams.sort - object with session sorting criteria
  * @returns {string} parsed string with the filters and sorting criteria to add to query
  * @module utils:api:utils
  * @example parseQueryParams({filters: {status: 'active'}}) => '?filters[status]=active&'
@@ -14,8 +14,8 @@ const parseQueryParams = (queryParams) => {
 	if (!isObject(queryParams) || !Object.keys(queryParams).length) return '';
 
 	const {filters, sort} = queryParams;
-	const validFilters = isObject(filters) && Object.keys(filters);
-	const validSort = !!sort && isString(sort);
+	const validFilters = isObject(filters) && Object.keys(filters).length;
+	const validSort = isObject(sort) && Object.keys(sort).length;
 
 	const parsedFilters = validFilters
 		? Object.entries(filters)
@@ -34,7 +34,15 @@ const parseQueryParams = (queryParams) => {
 				.join('')
 		: '';
 
-	const parsedSort = validSort ? `sortBy=${encodeURIComponent(sort)}` : '';
+	const parsedSort = validSort
+		? Object.entries(sort)
+				.map(([sort, value]) => {
+					if (value) return `${encodeURIComponent(sort)}=${encodeURIComponent(value)}`;
+					return '';
+				})
+				.filter(Boolean)
+				.join('&')
+		: '';
 
 	if (!parsedFilters && !parsedSort) return '';
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
 		"react-native-device-info": "^10.12.0"
 	},
 	"peerDependencies": {
-		"react": ">=17.0.2 <=18.2.0"
+		"react": ">=17.0.2"
 	}
 }

--- a/test/utils/makeRequest.test.js
+++ b/test/utils/makeRequest.test.js
@@ -62,6 +62,30 @@ describe('makeRequest function that return a new promise:', () => {
 		expect(result.statusText).toBeUndefined();
 	});
 
+	it('prop data can be array', async () => {
+		nock('https://sample-service.janis-test.in')
+			.post('/api/sample-entity')
+			.reply(200, mockMsResponse, headersResponse);
+
+		axios.mockResolvedValueOnce({
+			headers: {headersResponse},
+			status: 200,
+			data: {id: '1234'},
+		});
+
+		const result = await makeRequest({
+			httpVerb: 'POST',
+			url: 'https://sample-service.janis-test.in/api/sample-entity',
+			headers: {Authorization: 'Bearer token'},
+			crashConfig: {method: 'POST', service: 'example', namespace: 'test'},
+			data: [{id: '1234', email: 'janis@janis.im'}],
+		});
+
+		expect(result.result).toEqual({id: '1234'});
+		expect(result.statusCode).toEqual(200);
+		expect(result.statusText).toBeUndefined();
+	});
+
 	it('should reject with error when request fails', async () => {
 		nock('https://sample-service.janis-test.in')
 			.get('/api/sample-entity/1234')

--- a/test/utils/parseQueryParams.test.js
+++ b/test/utils/parseQueryParams.test.js
@@ -14,23 +14,33 @@ describe('parseQueryParams function', () => {
 	});
 
 	it('should return multiple filters correctly', () => {
-		const queryParams = {filters: {status: ['active', 'test'], id: '123'}};
+		const queryParams = {filters: {status: ['active', 'test'], id: '123'}, sort: {}};
 		expect(parseQueryParams(queryParams)).toBe(
 			'?filters[status][0]=active&filters[status][1]=test&filters[id]=123&',
 		);
 	});
 
 	it('should return sorting criteria correctly', () => {
-		const queryParams = {sort: 'prioritizeManualAssignment'};
+		const queryParams = {sort: {sortBy: 'prioritizeManualAssignment'}};
 		expect(parseQueryParams(queryParams)).toBe('?sortBy=prioritizeManualAssignment');
 	});
 
 	it('returns both filters and sorting criteria correctly', () => {
-		const queryParams = {filters: {status: 'active'}, sort: 'createdAt'};
+		const queryParams = {filters: {status: 'active'}, sort: {sortBy: 'createdAt'}};
 		expect(parseQueryParams(queryParams)).toBe('?filters[status]=active&sortBy=createdAt');
 	});
 
-	it('returns an empty sort string if sort is not a valid string', () => {
+	it('returns both filters and sorting criteria correctly', () => {
+		const queryParams = {
+			filters: {status: 'active'},
+			sort: {sortBy: 'createdAt', sortDirection: 'asc'},
+		};
+		expect(parseQueryParams(queryParams)).toBe(
+			'?filters[status]=active&sortBy=createdAt&sortDirection=asc',
+		);
+	});
+
+	it('returns an empty sort string if sort is not a valid object', () => {
 		const queryParams = {sort: ['status:asc', 'createdAt:desc']};
 		expect(parseQueryParams(queryParams)).toBe('');
 	});
@@ -45,7 +55,7 @@ describe('parseQueryParams function', () => {
 	});
 
 	it('returns both filters and sorting criteria correctly with empty values', () => {
-		const queryParams = {filters: {status: '', id: '123'}, sort: ''};
+		const queryParams = {filters: {status: '', id: '123'}, sort: {sortBy: ''}};
 		expect(parseQueryParams(queryParams)).toBe('?filters[id]=123&');
 	});
 });


### PR DESCRIPTION
**LINK DE TICKET:** 
https://janiscommerce.atlassian.net/browse/APPSRN-283

**DESCRIPCIÓN DEL REQUERIMIENTO:**

CONTEXTO
Actualmente, el módulo de request permite pasar, dentro del parámetro queryParams, una key sort con los criterios de ordenamiento que deben formar parte de los queryParams del endpoint al que le estamos pegando. Sin embargo, esta key sólo está permitiendo pasar un string para modificar la request con un criterio de ordenamiento que es el criterio sortBy.

Esto limita el uso que le podamos dar a los métodos ya que, de ser necesario otro criterio para organizar la información, no podremos utilizarlo por las validaciones utilizadas dentro del package.

Además de esto, nos está pasando que si queremos pasar un body con data como parte de nuestra request,  este debe ser específicamente de tipo object. Esto en la mayoría de casos no es un problema, pero en apis que esperan que su payload sea un array si lo es.

Si bien no hay tantos casos, la realidad es que estamos limitando el uso de nuestros métodos para tener un control más restringido del funcionamiento de los recursos y así evitar problemas, lo cual esta bien, pero deja de estarlo cuando complica al usuario.

NECESIDAD
Tenemos que modificar las validaciones de nuestras utils y métodos para que sean más permisivas y puedan ser utilizadas en más casos.

**Acceptance criteria**

Poder agregar más criterios de ordenamiento en las request.

Poder enviar arrays de información en el body de las request

**DESCRIPCIÓN DE LA SOLUCIÓN:**
-Se implemento prepareAndMakeRequest en los mtodos GET y LIST, estandarizando asi todos los metodos.
-Se modificaron las validaciones en makeRequest para que el body pueda venir en formato Array.
-Se modifico parseQueryParams para parsear de forma correcta el sort, recibiendo cualquier tipo d criterio de ordenamiento en formato object.

EXTRA
Se modifico la peerDpendenci de react en el json para permitir cualquier version suprior a la minima, para evitar tener que modificarla cuando actualicemos las apps.

**CÓMO SE PUEDE PROBAR?**

Para Validar se podría correr los test donde se comprueba cada caso de los ajustes implementados, tambien se puede linkear el repo para implementar en casos reales.

Para linkear el componente con un proyecto, seguir la siguiente documentación
https://fizzmod.atlassian.net/wiki/spaces/JAPP/pages/2341765125/C+mo+trabajo+con+el+package+UI

**OJO**
Tener en cuenta que la respuesta del request.get cambia, asi que hay que modificar como se recibe esta data en el repo para adaptarse a esta repuestas y que no rompa. (fijarse como se recibe la data en los otros metodos).

Habria que validar en una api donde se pase un criterio de ordenamiento distinto a ordenBy, pasando los criterios de esta manera por ejemplo
```
sort: {
  sortBy:'name',
  sortDirection:'asc'
}
```
Habria que validar en algun metodo push, pat, o post pasando la data correspondiente en forma d array, ya qu ahora es un valor permitido ademas del objeto.

Los metodos GET y LIST ahora pueden recibir los parametros estandar de los demas metodos, por lo que se puede hacer querys a un custom endPoint o pasar mas pathParams a la url.

CHANGELOG

```
### Feature

- [APPSRN-283](https://janiscommerce.atlassian.net/browse/APPSRN-283)
- Improved use of queryParams and sent data
- Updating GET and LIST methods 

```