### PR TITLE
crashlytics package was updated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "@janiscommerce/app-request",
 			"version": "2.0.0",
 			"dependencies": {
-				"@janiscommerce/app-crashlytics": "^2.0.0",
+				"@janiscommerce/app-crashlytics": "^2.1.0",
 				"@janiscommerce/oauth-native": "^1.4.0",
 				"axios": "^1.6.3"
 			},
@@ -28,7 +28,7 @@
 				"react-native-device-info": "^10.12.0"
 			},
 			"peerDependencies": {
-				"react": ">=17.0.2 <=18.2.0"
+				"react": ">=17.0.2"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -2192,16 +2192,40 @@
 			}
 		},
 		"node_modules/@janiscommerce/app-crashlytics": {
-			"version": "2.0.0",
-			"license": "ISC",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@janiscommerce/app-crashlytics/-/app-crashlytics-2.1.0.tgz",
+			"integrity": "sha512-xbpRi96nZJn07QhcEaqmGVagX4IUByV3/eojeUoOUBL02JuzHEVnfrFSeDWvujdFyQv2hdRPCy7XQSUw66oHDg==",
 			"dependencies": {
+				"@janiscommerce/app-device-info": "^1.1.0",
 				"@react-native-firebase/app": "^18.3.0",
-				"@react-native-firebase/crashlytics": "^18.3.2"
+				"@react-native-firebase/crashlytics": "^18.3.2",
+				"react-native-device-info": "^10.12.0"
 			},
 			"peerDependencies": {
 				"@janiscommerce/oauth-native": "^1.3.1",
 				"react": ">=17.0.2 <=18.2.0",
 				"react-native": ">=0.67.5 <=0.72.0"
+			}
+		},
+		"node_modules/@janiscommerce/app-device-info": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@janiscommerce/app-device-info/-/app-device-info-1.1.0.tgz",
+			"integrity": "sha512-TiB+xO8R59j7HDoa3p1NsRKyn3JQz9JAQJTyrcFk+YLxpQyZeCXFGlM9yds2p1fDOFwfSVIivpTV5aS5ix9C8Q==",
+			"dependencies": {
+				"@react-native-community/netinfo": "^9.3.10",
+				"react-native-device-info": "^8.5.0"
+			},
+			"peerDependencies": {
+				"@react-native-community/netinfo": ">=9.3.10",
+				"react-native-device-info": ">=8.5.0"
+			}
+		},
+		"node_modules/@janiscommerce/app-device-info/node_modules/react-native-device-info": {
+			"version": "8.7.1",
+			"resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-8.7.1.tgz",
+			"integrity": "sha512-cVMZztFa2Qn6qpQa601W61CtUwZQ1KXfqCOeltejAWEXmgIWivC692WGSdtGudj4upSi1UgMSaGcvKjfcpdGjg==",
+			"peerDependencies": {
+				"react-native": "*"
 			}
 		},
 		"node_modules/@janiscommerce/oauth-native": {
@@ -3995,6 +4019,14 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/@react-native-community/netinfo": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-9.5.0.tgz",
+			"integrity": "sha512-sppTBobjvIlPYXyDAyb5WJoBaQq1hprnHj1PWICsA10mVnlmwX5ZVkgO2vGjsfFtb+fmWK9XtZF+aQ6ijqQcwg==",
+			"peerDependencies": {
+				"react-native": ">=0.59"
 			}
 		},
 		"node_modules/@react-native-firebase/app": {
@@ -11325,7 +11357,6 @@
 		},
 		"node_modules/react-native-device-info": {
 			"version": "10.12.0",
-			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"react-native": "*"
@@ -14246,10 +14277,31 @@
 			"dev": true
 		},
 		"@janiscommerce/app-crashlytics": {
-			"version": "2.0.0",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@janiscommerce/app-crashlytics/-/app-crashlytics-2.1.0.tgz",
+			"integrity": "sha512-xbpRi96nZJn07QhcEaqmGVagX4IUByV3/eojeUoOUBL02JuzHEVnfrFSeDWvujdFyQv2hdRPCy7XQSUw66oHDg==",
 			"requires": {
+				"@janiscommerce/app-device-info": "^1.1.0",
 				"@react-native-firebase/app": "^18.3.0",
-				"@react-native-firebase/crashlytics": "^18.3.2"
+				"@react-native-firebase/crashlytics": "^18.3.2",
+				"react-native-device-info": "^10.12.0"
+			}
+		},
+		"@janiscommerce/app-device-info": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@janiscommerce/app-device-info/-/app-device-info-1.1.0.tgz",
+			"integrity": "sha512-TiB+xO8R59j7HDoa3p1NsRKyn3JQz9JAQJTyrcFk+YLxpQyZeCXFGlM9yds2p1fDOFwfSVIivpTV5aS5ix9C8Q==",
+			"requires": {
+				"@react-native-community/netinfo": "^9.3.10",
+				"react-native-device-info": "^8.5.0"
+			},
+			"dependencies": {
+				"react-native-device-info": {
+					"version": "8.7.1",
+					"resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-8.7.1.tgz",
+					"integrity": "sha512-cVMZztFa2Qn6qpQa601W61CtUwZQ1KXfqCOeltejAWEXmgIWivC692WGSdtGudj4upSi1UgMSaGcvKjfcpdGjg==",
+					"requires": {}
+				}
 			}
 		},
 		"@janiscommerce/oauth-native": {
@@ -15543,6 +15595,12 @@
 			"requires": {
 				"joi": "^17.2.1"
 			}
+		},
+		"@react-native-community/netinfo": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-9.5.0.tgz",
+			"integrity": "sha512-sppTBobjvIlPYXyDAyb5WJoBaQq1hprnHj1PWICsA10mVnlmwX5ZVkgO2vGjsfFtb+fmWK9XtZF+aQ6ijqQcwg==",
+			"requires": {}
 		},
 		"@react-native-firebase/app": {
 			"version": "18.7.3",
@@ -20567,7 +20625,6 @@
 		},
 		"react-native-device-info": {
 			"version": "10.12.0",
-			"dev": true,
 			"requires": {}
 		},
 		"react-native-inappbrowser-reborn": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"validate:code": "npm run lint -- --fix  && jest --collectCoverage"
 	},
 	"dependencies": {
-		"@janiscommerce/app-crashlytics": "^2.0.0",
+		"@janiscommerce/app-crashlytics": "^2.1.0",
 		"@janiscommerce/oauth-native": "^1.4.0",
 		"axios": "^1.6.3"
 	},


### PR DESCRIPTION
LINK DE TICKET: *

https://janiscommerce.atlassian.net/browse/APPSRN-294

LINK DE SUBTAREA:

https://janiscommerce.atlassian.net/browse/APPSRN-296

DESCRIPCIÓN DEL REQUERIMIENTO: *

**Contexto**

En el package de crashlytics se hicieron nuevas implementaciones, las cuales nos dan beneficios a la hora de trackear errores. Por ejemplo la calidad del internet y el id del dispositivo. Esto conlleva a que para usarlos, se requiera actualizar.

**Requerimiento**

Se necesita actualizar crashlytics en el package de app-request

DESCRIPCIÓN DE LA SOLUCIÓN: *

Se actualizó el package de crashlytics con la última versión publicada (2.1.0) https://www.npmjs.com/package/@janiscommerce/app-crashlytics

CÓMO SE PUEDE PROBAR? *

Lo que hay que probar es que crashlytics tenga la información de conexión (`connection`) y ID del dispositivo (`deviceId`) y, para poder validar eso, habría que hacer lo siguiente:

Hay que entrar en la clase de request y, en el catch del método `prepareAndMakeRequest`, agregar un console.log similar a este:

```js
console.log('crashlytics user data', crashlytics.userData)
```

Luego, hay que buscar en la app alguna implementación de los métodos de request y eliminar algún campo que sea considerado como requerido para que se produzca un error ( namespace o service está bien )

Cuando haga esto, y trate de ejecutar esa implementación, le va a tirar un error porque le falta algún campo requerido, pero lo que nos importa es que el console.log que aparezca en la consola sea similar a esto:

```js
{
   "client":"fizzmodarg",
   "connection":"3g",
   "currency":"ARS",
   "deviceId":"4182ab98e0ca76e6",
   "isDev":true,
   "language":"en-US",
   "userEmail":"janis@janis.im",
   "userId":"fjasfaj123142143123jfas",
   "userName":"Janis",
   "userSurname":"Fizzmod"
}
```

CHANGELOG:

```js
###Added
- Added more data in the errors registered in crashlytics [APPSRN-294](https://janiscommerce.atlassian.net/browse/APPSRN-294)
```

[APPSRN-294]: https://janiscommerce.atlassian.net/browse/APPSRN-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ