### PR TITLE
fixed error handling at makeRequest

### DIFF
--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -34,21 +34,31 @@ const makeRequest = ({httpVerb, url, data, headers, extendedConfig, crashConfig}
 				});
 			})
 			.catch((error) => {
-				const {data: errorData = {}, status = '', statusText = ''} = error.response;
-				const validMessage = errorData?.message;
+				if (error.response) {
+					// The request was made and the server responded with a status code
+					// that falls out of the range of 2xx
+					const {data: errorData = {}, status = '', statusText = ''} = error.response;
+					const validMessage = errorData?.message;
 
-				if (isString(validMessage) && validMessage) error.message = validMessage;
+					if (isString(validMessage) && validMessage) error.message = validMessage;
+
+					reject({
+						result: errorData,
+						statusCode: status,
+						statusText: statusText,
+					});
+				} else if (error.request) {
+					//Request was made but no response was received
+					reject({result: {message: error.message}});
+				} else {
+					//Something happened in setting up the request that triggered an Error
+					reject({result: {message: error.message}});
+				}
 
 				crashlytics.recordError(
 					error,
 					`Error at ${method}: service: ${service} namespace: ${namespace} ${id ? `id: ${id}` : ''} URL:${url}`,
 				);
-
-				reject({
-					result: errorData,
-					statusCode: status,
-					statusText,
-				});
 			});
 	});
 

--- a/test/utils/makeRequest.test.js
+++ b/test/utils/makeRequest.test.js
@@ -139,4 +139,51 @@ describe('makeRequest function that return a new promise:', () => {
 			statusText: 'unauthorized token',
 		});
 	});
+
+	it('should reject with error.message when error.response is undefined and error.request is truthy', async () => {
+		nock('https://sample-service.janis-test.in')
+			.get('/api/sample-entity/1234')
+			.reply(403, mockMsResponse, headersResponse);
+
+		axios.mockRejectedValueOnce({
+			message: 'Request was made but no response was received',
+			request: {data: 123},
+		});
+
+		crashlytics.recordError = jest.fn();
+
+		await expect(
+			makeRequest({
+				httpVerb: 'GET',
+				url: 'https://sample-service.janis-test.in/api/sample-entity/1234',
+				headers: {Authorization: 'Bearer token'},
+				crashConfig: {method: 'GET', service: 'example', namespace: 'test', id: '1234'},
+			}),
+		).rejects.toEqual({
+			result: {message: 'Request was made but no response was received'},
+		});
+	});
+
+	it('should reject with error.message when error.response and error.request are undefined', async () => {
+		nock('https://sample-service.janis-test.in')
+			.get('/api/sample-entity/1234')
+			.reply(403, mockMsResponse, headersResponse);
+
+		axios.mockRejectedValueOnce({
+			message: 'Network Error',
+		});
+
+		crashlytics.recordError = jest.fn();
+
+		await expect(
+			makeRequest({
+				httpVerb: 'GET',
+				url: 'https://sample-service.janis-test.in/api/sample-entity/1234',
+				headers: {Authorization: 'Bearer token'},
+				crashConfig: {method: 'GET', service: 'example', namespace: 'test', id: '1234'},
+			}),
+		).rejects.toEqual({
+			result: {message: 'Network Error'},
+		});
+	});
 });


### PR DESCRIPTION
Contexto
En base al siguiente HDI https://janiscommerce.atlassian.net/browse/HDI-2054
Se encontro que si al momento de realizar una request, se desconecta el dispositivo de internet, la promesa nunca se rechaza.
Por lo que desde la app se pueden generar loops ya que la request no devuelve ni data ni error.

Solucion
En base a la documentacion oficial de axios https://axios-http.com/docs/handling_errors
Manejamos el escenario donde la request no se hace por falta de internet o hubo algun error al preparar la request