### PR TITLE
added query filters support by objects

### DIFF
--- a/lib/utils/parseQueryParams.js
+++ b/lib/utils/parseQueryParams.js
@@ -27,6 +27,16 @@ const parseQueryParams = (queryParams) => {
 									`filters[${encodeURIComponent(filter)}][${index}]=${encodeURIComponent(val)}&`,
 							)
 							.join('');
+					if (value && isObject(value) && !!Object.keys(value).length) {
+						const objectKeys = Object.keys(value);
+
+						return objectKeys
+							.map(
+								(key) =>
+									`filters[${encodeURIComponent(filter)}][${key}]=${encodeURIComponent(value[key])}&`,
+							)
+							.join('');
+					}
 					if (value) return `filters[${encodeURIComponent(filter)}]=${encodeURIComponent(value)}&`;
 					return '';
 				})

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
 				"@janiscommerce/app-analytics": "^2.4.0",
 				"@janiscommerce/app-crashlytics": "^2.1.0",
 				"@janiscommerce/oauth-native": "^1.4.0",
-				"react": ">=17.0.2"
+				"react": ">=17.0.2",
+				"react-native-device-info": "^10.12.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {


### PR DESCRIPTION
CONTEXTO:

Trabajando en el ticket https://janiscommerce.atlassian.net/browse/JPRN-1963 nos dimos cuenta que el modulo de request no estaba preparado para recibir un filtro cuyo valor venga en formato objeto, como es el caso de https://docs.janisdev.in/v2/service/packing#operation/listPackages en el filtro `dateCreatedRange`, que espera recibir un objeto con las claves `from` y `to`, y sus valores correspondientes.
Debido a esto surgió la necesidad de agregar unos ajustes que permitan que request pueda procesar filtros cuyo valor sea un objeto para adaptarlo y poder usarlo como parte de la URL de la request.

SOLUCIÓN:

Se agregó un condicional nuevo dentro de `parseQueryParams` que valida que el filtro recibido sea un objeto o no. Si no lo es lo ignora y no entra en la condición, pero si lo es se toman los valores del objeto para armar la query que va a utilizarse en la request.