### PR TITLE
Fix sort params

### DIFF
--- a/lib/utils/parseQueryParams.js
+++ b/lib/utils/parseQueryParams.js
@@ -50,8 +50,7 @@ const parseQueryParams = (queryParams) => {
 					if (value && !!value.length && isArray(value))
 						return value
 							.map(
-								(val, index) =>
-									`${encodeURIComponent(sort)}[${index}]=${encodeURIComponent(val)}&`,
+								(val, index) => `${encodeURIComponent(sort)}[${index}]=${encodeURIComponent(val)}&`,
 							)
 							.join('');
 					if (value) return `${encodeURIComponent(sort)}=${encodeURIComponent(value)}`;

--- a/lib/utils/parseQueryParams.js
+++ b/lib/utils/parseQueryParams.js
@@ -47,6 +47,13 @@ const parseQueryParams = (queryParams) => {
 	const parsedSort = validSort
 		? Object.entries(sort)
 				.map(([sort, value]) => {
+					if (value && !!value.length && isArray(value))
+						return value
+							.map(
+								(val, index) =>
+									`${encodeURIComponent(sort)}[${index}]=${encodeURIComponent(val)}&`,
+							)
+							.join('');
 					if (value) return `${encodeURIComponent(sort)}=${encodeURIComponent(value)}`;
 					return '';
 				})


### PR DESCRIPTION
CONTEXTO:

Actualmente, el package de request no está preparado para que, en los criterios de ordenamiento, se utilicen valores de tipo array como argumento para el ordenamiento que se quiere realizar.
Esta carencia limita el funcionamiento de nuestras request, obligandonos a que todos nuestros criterios sólo puedan recibir un argumento, y hay casos en los que podríamos necesitar más de uno.

NECESIDAD:

Ajustar el funcionamiento de la función encargada de preparar los query params para que, en caso de recibir un argumento de tipo array para los criterios de ordenamiento, organice los valores de una manera similar a cómo lo hace con los filtros.

SOLUCIÓN:

Se modificó la función `parseQueryParams` para que pueda serializar los parámetros de ordenamiento en caso de que estos sean arrays.

![Captura desde 2024-11-04 13-41-02](https://github.com/user-attachments/assets/1be94484-c483-4d75-bfac-207f37a203c0)

¿CÓMO SE PUEDE PROBAR?

Tomar una request de tipo list y agregar un array como valor para cualquier criterio de ordenamiento. En caso de que el valor dentro del array sea valido la request debería funcionar sin problemas.