### PR TITLE
Improved error messages linked to authentication key expiration.

### DIFF
--- a/lib/utils/getTokenAndClient.js
+++ b/lib/utils/getTokenAndClient.js
@@ -1,14 +1,10 @@
 import {getUserInfo, getAccessToken} from '@janiscommerce/oauth-native';
-import {promiseWrapper, isObject} from './helpers.js';
 
 const getTokenAndClient = async () => {
 	try {
-		const [userInfo, errorUserInfo] = await promiseWrapper(getUserInfo());
-		if (!isObject(userInfo) || errorUserInfo) throw new Error('error getting userInfo');
+		const userInfo = await getUserInfo();
 
-		const [accessToken, errorAccessToken] = await promiseWrapper(getAccessToken());
-		if (!accessToken || errorAccessToken)
-			throw new Error('error getting oauthTokens from async storages');
+		const accessToken = await getAccessToken();
 
 		const {tcode} = userInfo;
 


### PR DESCRIPTION
## ATENCIÓN:
# Antes de mergear estas modificaciones se debe haber resuelto el [PR](https://github.com/janis-commerce/oauth-native/pull/10) de oauth native y también haber actualizado la versión de ese pkg en este repositorio.

### Requisitos

- [ ] PR de oauth-native aprobado
- [ ] Versión de oauth-native actualizada en package.json


### CONTEXTO:
En los últimos días, walmart costa rica reportó que, cuando estaban por finalizar el flujo de picking sobre una ronda, recibieron este mensaje de error por parte de la app:

![Finazalir repack](https://github.com/user-attachments/assets/cf60fa6d-f1a4-4218-94ba-1be383af21bc)

El error en cuestión es: "error getting userInfo"; y revisando el código encontramos que ese error lo estamos devolviendo cuando la función encargada de obtener esa información falla o no retorna la información esperada.
Sin embargo, independientemente del mótivo del fallo, el pkg de request retorna el mismo mensaje, lo que dificulta poder identificar cuál fue la verdadera razón del error.

### NECESIDAD:
Mejorar el manejo de errores relacionado a la obtención de tokens de autenticación para poder mostrar el mensaje correspondiente de cara al usuario para facilitar el entendimiento del problema.

### SOLUCIÓN:
Para no entorpecer el mensaje de error que retornan los métodos de request en caso de que se produzca una falla durante la obtención de tokens de autenticación, se ajustó el funcionamiento de la util `getTokenAndClient` para que, en vez de retornar su propio mensaje de error, se dedique a devolver el que obtuvo desde oauth-native.

![Peek 2024-12-09 14-51](https://github.com/user-attachments/assets/14b5039e-c597-4345-af0b-5d7796bbeb25)
