### PR TITLE
Fixed status_code and response_time keys not showing up on Analytics

### DIFF
--- a/lib/utils/axiosInstance.js
+++ b/lib/utils/axiosInstance.js
@@ -27,7 +27,7 @@ axiosInstance.interceptors.request.use((config) => {
 
 	if (availableEnvironments.includes(appName)) {
 		config.metadata = {};
-		analytics = new Analytics({appVersion, isDebugMode: true});
+		analytics = new Analytics({appVersion});
 		config.metadata = {startTime: new Date()};
 	}
 

--- a/lib/utils/axiosInstance.js
+++ b/lib/utils/axiosInstance.js
@@ -27,7 +27,7 @@ axiosInstance.interceptors.request.use((config) => {
 
 	if (availableEnvironments.includes(appName)) {
 		config.metadata = {};
-		analytics = new Analytics({appVersion});
+		analytics = new Analytics({appVersion, isDebugMode: true});
 		config.metadata = {startTime: new Date()};
 	}
 
@@ -44,11 +44,11 @@ axiosInstance.interceptors.response.use(
 			response.duration = response.config.metadata.endTime - response.config.metadata.startTime;
 			if (analytics) {
 				analytics.sendAction('measurement_requests', null, {
-					response_time: response?.duration,
+					response_time: String(response?.duration),
 					params_endpoint: response?.request?.responseURL?.split('?')[1]?.substring(0, 100),
 					data_size: response?.headers['content-length'] || '0',
 					base_endpoint: response?.request?.responseURL?.split('?')[0] || '',
-					status_code: response?.status,
+					status_code: String(response?.status),
 					app_version: response?.config?.headers?.['janis-app-version'],
 				});
 			}


### PR DESCRIPTION
Link del tkt

https://janiscommerce.atlassian.net/browse/APPSRN-350

Descripción

Se observo que cierta data de measurement_requests llega incompleta a Analytics, específicamente las keys response_time y status_code

Acceptance criteria

Se requiere corregir la acción de measurement_requests ya que la misma llega incompleta en algunos casos

Solución

Se agregó un String() para estas dos keys