### PR TITLE
Updated oauth-native package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
 		"react-native-device-info": "^10.12.0",
 		"@janiscommerce/app-analytics": "^2.4.0",
 		"@janiscommerce/app-crashlytics": "^2.1.0",
-		"@janiscommerce/oauth-native": "^1.4.0"
+		"@janiscommerce/oauth-native": "^1.4.1"
 	},
 	"peerDependencies": {
 		"react": ">=17.0.2",
 		"react-native-device-info": "^10.12.0",
 		"@janiscommerce/app-analytics": "^2.4.0",
 		"@janiscommerce/app-crashlytics": "^2.1.0",
-		"@janiscommerce/oauth-native": "^1.4.0"
+		"@janiscommerce/oauth-native": "^1.4.1"
 	}
 }


### PR DESCRIPTION
LINK:
https://janiscommerce.atlassian.net/browse/APPSRN-356

CONTEXTO:
Estamos buscando encarar la siguiente épica: https://janiscommerce.atlassian.net/browse/ATR-1516, para la misma se necesita de antemano solucionar el error de "Cannot convert null value to object" en la app de Picking que se produce al ingresar en la Home de la app tras levantarla y dejar el fix también en el resto de las apps

![333705743-c3510461-bbce-422d-b71c-c5235967b7a8](https://github.com/user-attachments/assets/6008a5bb-9ff8-4329-b498-91319d223050)


NECESIDAD:
Actualizar la versión del package oauth-native dentro del package de app request para que se solucione el error de "Cannot convert null value to object"

SOLUCIÓN:
Se actualizó la versión del package dentro de app request

CÓMO PROBARLO?:

Levantando la app de picking y verificando que el error no aparezca en la Home.
